### PR TITLE
Corrección hero-clip-path-button

### DIFF
--- a/style.css
+++ b/style.css
@@ -164,6 +164,7 @@ body {
   }
   .hero-clip-path-button {
     position: absolute;
+    display: none;
   }
 }
 


### PR DESCRIPTION
Oculté el hero-clip-path-button en dispositivos con un ancho menor a 600px, el elemento se sobreponía tapando el contenido y el botón (en versiones más pequeñas) del hero.